### PR TITLE
Add .gemrc

### DIFF
--- a/gemrc
+++ b/gemrc
@@ -1,0 +1,2 @@
+---
+gem: --no-document


### PR DESCRIPTION
Tell RubyGems to skip documentation when installing gems.
