### PR TITLE
Add ~/.bash_aliases

### DIFF
--- a/bash_aliases
+++ b/bash_aliases
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+alias ..='cd ..'
+alias pag='ps aux | head -n1; ps aux | grep -i'


### PR DESCRIPTION
Adds two handy aliases to start with.
- `..`
  
  Moves up a directory.
- `pag`
  
  Searches the process list for processes matching `PATTERN` using `grep(1)` and
  prints results including a helpful header.
  
  Usage: `pag PATTERN`
  
  Example:
  
  ```
  $ pag vim
  USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
  koronen   6552  0.0  0.0  12744  2296 pts/5    S+   10:46   0:00 grep -i vim
  ```

This file is sourced from `~/.bashrc` by default on fresh Ubuntu installations.
